### PR TITLE
Reconcile steering committee list with MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,10 +1,15 @@
-# community maintainers
+# CoCo Steering Committee / Maintainers
 #
 # Github ID, Name, Email Address
 
 ariel-adam, Ariel Adam, aadam@redhat.com
 bpradipt, Pradipta Banerjee, prbanerj@redhat.com
+dcmiddle, Dan Middleton, dan.middleton@intel.com
+fitzthum, Tobin Feldman-Fitzthum, tobin@ibm.com
 jiazhang0, Zhang Jia, zhang.jia@linux.alibaba.com
 Jiang Liu, jiangliu, gerry@linux.alibaba.com
 larrydewey, Larry Dewey, Larry.Dewey@amd.com
-fitzthum, Tobin Feldman-Fitzthum, tobin@ibm.com
+magowan, James Magowan, magowan@uk.ibm.com
+peterzcst, Peter Zhu, peter.j.zhu@intel.com
+sameo, Samuel Ortiz, samuel.e.ortiz@protonmail.com
+


### PR DESCRIPTION
CNCF requires a MAINTAINERS file that matches our steering committee.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>