### PR TITLE
templates: Ensure the release-check-list template is displayed

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-check-list.md
+++ b/.github/ISSUE_TEMPLATE/release-check-list.md
@@ -1,3 +1,11 @@
+---
+name: New project release
+about: Checklist for the coming project's release
+title: "[Release] Check list for v<TARGET_RELEASE>"
+labels: ''
+assignees: ''
+---
+
 # v<TARGET_RELEASE>
 
 ## Code freeze


### PR DESCRIPTION
It seems that we have to have a table with some basic information otherwise GitHub won't be able to display the template information to the users.