### PR TITLE
WIP: Manage Self-hosted runners with Garm

### DIFF
--- a/ci/garm/Makefile
+++ b/ci/garm/Makefile
@@ -1,0 +1,26 @@
+ifeq ($(SUFFIX),)
+	SUFFIX := $(shell bash -c 'echo $$RANDOM | md5sum | head -c 6')
+endif
+LOCATION ?= eastus
+ACI_NAME := garm-$(SUFFIX)
+RESOURCE_GROUP ?= replaceme
+STORAGE_ACCOUNT ?= replaceme
+
+.PHONY: deploy
+deploy:
+	az deployment group create \
+		--template-file ./arm/aci.bicep \
+		--resource-group=$(RESOURCE_GROUP) \
+		--name $(ACI_NAME) \
+		--parameters StorageAccount=$(STORAGE_ACCOUNT) \
+		--parameters Name=$(ACI_NAME) \
+		--parameters Location=$(LOCATION) \
+		--parameters DnsNameLabel=$(ACI_NAME) && \
+	echo $(ACI_NAME).$(LOCATION).azurecontainer.io
+
+.PHONY: delete
+delete:
+	az container delete \
+		--resource-group $(RESOURCE_GROUP) \
+		--name garm-$(SUFFIX) \
+		--yes

--- a/ci/garm/README.md
+++ b/ci/garm/README.md
@@ -1,0 +1,11 @@
+# Garm
+
+Deploy https enabled ACI container using Caddy + letsencrypt:
+
+```bash
+export RESOURCE_GROUP=myrg
+export STORAGE_ACCOUNT=mysa
+make deploy 
+```
+
+Wait a bit (~1m) before attempting to open the url.

--- a/ci/garm/arm/aci.bicep
+++ b/ci/garm/arm/aci.bicep
@@ -1,0 +1,110 @@
+@description('Name for the container group')
+param Name string
+
+@description('Location for all resources.')
+param Location string
+
+@description('Storage Account Name for Caddy File Share')
+param StorageAccount string
+
+@description('DNS Name Label for the Public IP Address')
+param DnsNameLabel string
+
+param Image string = 'mcr.microsoft.com/azuredocs/aci-helloworld'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' existing = {
+  name: StorageAccount
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  name: '${storageAccount.name}/default/${Name}'
+}
+
+resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-09-01' = {
+  name: Name
+  location: Location
+  properties: {
+    containers: [
+      {
+        name: 'app'
+        properties: {
+          image: Image
+          environmentVariables: [
+            // note: Caddy requires port 80 & 443 to be exposed
+            {
+              name: 'PORT'
+              value: '3000'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: 1
+              memoryInGB: json('0.5')
+            }
+          }
+        }
+      }
+      {
+        name: 'caddy'
+        properties: {
+          image: 'caddy:2.6.4'
+          ports: [
+            {
+              port: 80
+              protocol: 'TCP'
+            }
+            {
+              port: 443
+              protocol: 'TCP'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: 1
+              memoryInGB: json('0.5')
+            }
+          }
+          volumeMounts: [
+            {
+              name: 'caddy-data'
+              mountPath: '/data'
+            }
+          ]
+          command: [
+            'caddy'
+            'reverse-proxy'
+            '--from'
+            '${DnsNameLabel}.${Location}.azurecontainer.io'
+            '--to'
+            'localhost:3000'
+          ]
+        }
+      }
+    ]
+    osType: 'Linux'
+    ipAddress: {
+      type: 'Public'
+      ports: [
+        {
+          port: 80
+          protocol: 'TCP'
+        }
+        {
+          port: 443
+          protocol: 'TCP'
+        }
+      ]
+      dnsNameLabel: DnsNameLabel
+    }
+    volumes: [
+      {
+        name: 'caddy-data'
+        azureFile: {
+          shareName: Name
+          storageAccountName: storageAccount.name
+          storageAccountKey: listKeys(storageAccount.id, storageAccount.apiVersion).keys[0].value
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
related to #77.

Exploration on how to have a lightweight mgmt solution for Self-hosted runners on Azure using [Garm ](https://github.com/cloudbase/garm).

Garm needs a Webhook exposed on the Internet that can be called by GitHub to register workloads. Potentially we can have lightweight solution with [ACI](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-overview) using letsencrypt, managed identity, sqlite on a volume.