### PR TITLE
guides: enclave-cc: fix KBS setup hyperlink

### DIFF
--- a/guides/enclave-cc.md
+++ b/guides/enclave-cc.md
@@ -19,7 +19,7 @@ https://github.com/intel/SGXDataCenterAttestationPrimitives) running on every SG
 ## Configuring enclave-cc custom resource to use a different KBC
 
 **Note** Before configuring KBC, please refer to the
-[guide](../quickstart.md#deploy-and-configure-tenant-side-coco-key-broker-system-cluster) to deploy KBS cluster.
+[guide](coco-dev.md#deploy-and-configure-tenant-side-coco-key-broker-system-cluster) to deploy KBS cluster.
 
 **Note** The KBC configuration changes to the enclave-cc custom resource yaml 
 must be made **before** deploying it. 


### PR DESCRIPTION
The quickstart guide rework to split docs in TEE specific guides broke the KBS setup anchor (looks like our url linter does not catch these).

Closes: #296 