### PR TITLE
governance: replace myself on the steering committee

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -87,7 +87,7 @@ The current members of the SC are:
 
 * Ryan Savino (@ryansavino) - AMD
 * Jiang Liu (@jiangliu) and Jia Zhang (@jiazhang0) - Alibaba
-* James Magowan (@magowan)  and Tobin Feldman-Fitzthum (@fitzthum) - IBM
+* James Magowan (@magowan) and Nina Goradia (@ninag) - IBM
 * Peter Zhu (@peterzcst) and Mikko Ylinen (@mythi) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
@@ -98,6 +98,7 @@ The current members of the SC are:
 
 * Dan Middleton [dcmiddle](https://github.com/dcmiddle) (he/him)
 * Larry Dewey (@larrydewey) - AMD
+* Tobin Feldman-Fitzthum (@fitzthum) - IBM
 
 #### Selection
 


### PR DESCRIPTION
Since I no longer work at IBM, I can no longer occupy an IBM seat on the steering commitee. Pursuant to the replacement clause of the governance document, I am replacing myself with Nina Goradia from IBM. This does not require a steering committee vote, but it must be approved by the other IBM representative, James Magowan.

I think Nina will be a great fit for the steering commitee.

Thanks for a wonderful chapter.

(dw I'm still working on the project)