### PR TITLE
Revert "sc: add Tobin to SC for NVIDIA"

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,11 +7,11 @@ bpradipt, Pradipta Banerjee, Redhat
 peterzcst, Peter Zhu, Intel
 mythi, Mikko Ylinen, Intel
 magowan, James Magowan, IBM
+fitzthum, Tobin Feldman-Fitzthum, IBM
 jiazhang0, Zhang Jia, Alibaba
 jiangliu, Jiang Liu, Alibaba
 ryansavino, Ryan Savino, AMD
 sameo, Samuel Ortiz, Rivos
 zvonkok, Zvonko Kaiser, NVIDIA
-fitzthum, Tobin Feldman-Fitzthum, NVIDIA
 vbatts, Vincent Batts, Microsoft
 danmihai1, Dan Mihai, Microsoft

--- a/governance.md
+++ b/governance.md
@@ -91,13 +91,14 @@ The current members of the SC are:
 * Peter Zhu (@peterzcst) and Mikko Ylinen (@mythi) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
-* Zvonko Kaiser (@zvonkok) and Tobin Feldman-Fitzthum (@fitzthum) - NVIDIA
+* Zvonko Kaiser (@zvonkok) - NVIDIA
 * Vincent Batts (@vbatts) and Dan Mihai (@danmihai1) - Microsoft
 
 ### Emeritus Members
 
 * Dan Middleton [dcmiddle](https://github.com/dcmiddle) (he/him)
 * Larry Dewey (@larrydewey) - AMD
+* Tobin Feldman-Fitzthum (@fitzthum) - IBM
 
 #### Selection
 


### PR DESCRIPTION
Reverts confidential-containers/confidential-containers#324

This has to be approved by 2/3rds of the SC. Let's try again.