### PR TITLE
sc: add Tobin to SC for NVIDIA

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,11 +7,11 @@ bpradipt, Pradipta Banerjee, Redhat
 peterzcst, Peter Zhu, Intel
 mythi, Mikko Ylinen, Intel
 magowan, James Magowan, IBM
-fitzthum, Tobin Feldman-Fitzthum, IBM
 jiazhang0, Zhang Jia, Alibaba
 jiangliu, Jiang Liu, Alibaba
 ryansavino, Ryan Savino, AMD
 sameo, Samuel Ortiz, Rivos
 zvonkok, Zvonko Kaiser, NVIDIA
+fitzthum, Tobin Feldman-Fitzthum, NVIDIA
 vbatts, Vincent Batts, Microsoft
 danmihai1, Dan Mihai, Microsoft

--- a/governance.md
+++ b/governance.md
@@ -91,14 +91,13 @@ The current members of the SC are:
 * Peter Zhu (@peterzcst) and Mikko Ylinen (@mythi) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
-* Zvonko Kaiser (@zvonkok) - NVIDIA
+* Zvonko Kaiser (@zvonkok) and Tobin Feldman-Fitzthum (@fitzthum) - NVIDIA
 * Vincent Batts (@vbatts) and Dan Mihai (@danmihai1) - Microsoft
 
 ### Emeritus Members
 
 * Dan Middleton [dcmiddle](https://github.com/dcmiddle) (he/him)
 * Larry Dewey (@larrydewey) - AMD
-* Tobin Feldman-Fitzthum (@fitzthum) - IBM
 
 #### Selection
 


### PR DESCRIPTION
NVIDIA has been a major contributor to Confidential Containers and more contributions are coming.

As such, let's expand the NVIDIA representation on the SC to two seats.

Per the expansion section of the governance document, this must be approved by two-thirds of current steering committee members.