### PR TITLE
Release template: Refer to the user to the helper script

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-check-list.md
+++ b/.github/ISSUE_TEMPLATE/release-check-list.md
@@ -91,7 +91,7 @@ Identify/create the bundles that we will release for Kata and enclave-cc.
 
 - [ ] 4. :wrench: **Open a PR to the operator to update the release artifacts**
 
-    Update the operator to use the payloads identified in steps 1, 2, 3, and 4.
+    Update the operator to use the payloads identified in steps 1, 2, and 3.
 
     Make sure that the operator pulls the most recent version of the pre-install container
 


### PR DESCRIPTION
Per @wainersm's suggestion [here](https://github.com/confidential-containers/operator/pull/452#discussion_r1786734386), we should add a note in the release template about our helper script.

Depends on https://github.com/confidential-containers/operator/pull/452