### PR TITLE
Add Harshitha to SC for AMD

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,6 +11,7 @@ ngoradia, Nina Goradia, IBM
 jiazhang0, Zhang Jia, Alibaba
 jiangliu, Jiang Liu, Alibaba
 ryansavino, Ryan Savino, AMD
+hgowda-amd, Harshitha Gowda, AMD
 sameo, Samuel Ortiz, Rivos
 zvonkok, Zvonko Kaiser, NVIDIA
 fitzthum, Tobin Feldman-Fitzthum, NVIDIA

--- a/governance.md
+++ b/governance.md
@@ -85,10 +85,10 @@ Further, as leaders in the community, the SC members will make themselves famili
 
 The current members of the SC are:
 
-* Ryan Savino (@ryansavino) - AMD
 * Jiang Liu (@jiangliu) and Jia Zhang (@jiazhang0) - Alibaba
 * James Magowan (@magowan) and Nina Goradia (@ngoradia) - IBM
 * Mikko Ylinen (@mythi) and Bartlomiej Sulich (@bsulich2) - Intel
+* Ryan Savino (@ryansavino) and Harshitha Gowda(@hgowda-amd) - AMD
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
 * Zvonko Kaiser (@zvonkok) and Tobin Feldman-Fitzthum (@fitzthum) - NVIDIA


### PR DESCRIPTION
AMD has made significant contributions in the past to Confidential Containers, particularly around SEV-SNP support. We are planning to expand these efforts further, with a focus on adding SNP reference values for SNP attestation, improving unit test coverage, and increasing overall code coverage for SEV-SNP use cases.

More contributions are planned going forward.
So, we would like to request the SC members to increase AMD representation on the SC to two seats.

Signed-off-by: Harshitha Gowda <hgowda@amd.com>