### PR TITLE
roadmap: update roadmap document

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -5,14 +5,23 @@ When looking at the project's roadmap we distinguish between the short-term road
 - The [mid and long term roadmap](#mid-and-long-term-roadmap) focuses on use case driven development.
 
 # Short Term Roadmap
-The short-term roadmap is based on our github boards and delivered through our on-going releases
+The short term roadmap can be found on two different GitHub projects
+Our [release project](https://github.com/orgs/confidential-containers/projects/6) tracks development
+that is associated with a particular release.
+See the view for the upcoming release to find work that might land in the next two months.
 
-- [Confidential containers github board](https://github.com/orgs/confidential-containers/projects/6/views/22)
-- [Trustee github board](https://github.com/orgs/confidential-containers/projects/10/views/1)
+There is also a [Trustee project](https://github.com/orgs/confidential-containers/projects/10/views/1) for Trustee-specific development.
+This project is not time-based. It tracks requirements in different stages of implementation.
+The second and third columns contain requirements that are in the process of being implemented.
+
+Both of these boards are populated by developers. They might not contain every piece of ongoing development,
+but they should give a sense of the short-term road map.
+Please add any work that you are doing to the appropriate project.
 
 # Mid and Long Term Roadmap
 
-In CoCo use case driven development we identify the main functional requirements the community requires by focusing on key use cases.
+The above project also feature some more longterm work, but our longterm roadmap mainly
+focuses on delivering key use cases (rather than specific features).
 
 This helps the community deliver releases which address real use cases customers require and focusing on the right priorities. The use case driven development approach also includes developing the relevant CI/CDs to ensure end-to-end use cases the community delivers work over time.
 


### PR DESCRIPTION
Clarify the roadmap document a little bit and change the link to the CoCo releases project to point to the entire project rather than a particular view (because we deleted the view it used to point to).