### PR TITLE
docs: fix link check failures in CI

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,4 @@
 https://sigs.centos.org/virt/tdx/
 https://www.intel.com/
+https://asciinema.org/
+https://docs.redhat.com/

--- a/releases/v0.13.0.md
+++ b/releases/v0.13.0.md
@@ -7,7 +7,7 @@ and [v0.11.0](https://github.com/confidential-containers/enclave-cc/releases/tag
 
 Kata and the CoCo components share an MSRV of 1.80.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## What's new
 

--- a/releases/v0.14.0.md
+++ b/releases/v0.14.0.md
@@ -7,7 +7,7 @@ and [v0.11.0](https://github.com/confidential-containers/enclave-cc/releases/tag
 
 Kata and the CoCo components share an MSRV of 1.80.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## What's new
 

--- a/releases/v0.15.0.md
+++ b/releases/v0.15.0.md
@@ -7,7 +7,7 @@ and [v0.11.0](https://github.com/confidential-containers/enclave-cc/releases/tag
 
 Trustee and the guest components use KBS protocol v0.4.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 
 ## What's New

--- a/releases/v0.16.0.md
+++ b/releases/v0.16.0.md
@@ -7,7 +7,7 @@ and [v0.11.0](https://github.com/confidential-containers/enclave-cc/releases/tag
 
 Trustee and the guest components use KBS protocol v0.4.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * Support for process-based confidential computing via enclave-cc will be removed in the v0.18.0 release.

--- a/releases/v0.17.0.md
+++ b/releases/v0.17.0.md
@@ -7,7 +7,7 @@ and [v0.11.0](https://github.com/confidential-containers/enclave-cc/releases/tag
 
 Trustee and the guest components use KBS protocol v0.4.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * Support for process-based confidential computing via enclave-cc will be removed in the v0.18.0 release.

--- a/releases/v0.18.0.md
+++ b/releases/v0.18.0.md
@@ -7,7 +7,7 @@ This release is based on [3.25.0](https://github.com/kata-containers/kata-contai
 This release uses v0.17.0 of Trustee and guest components.
 Trustee and the guest components use KBS protocol v0.4.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * Support for process-based confidential computing via enclave-cc has been removed.

--- a/releases/v0.19.0.md
+++ b/releases/v0.19.0.md
@@ -9,7 +9,7 @@ Trustee and the guest components use KBS protocol v0.4.0.
 
 Trustee and guest components use Rust v1.90.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * Go support in CDH was removed.

--- a/releases/v0.20.0.md
+++ b/releases/v0.20.0.md
@@ -14,7 +14,7 @@ Trustee and the guest components use KBS protocol v0.4.0.
 
 Trustee and guest components use Rust v1.90.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * The Docker CAA provider is deprecated and planned to be dropped in the next release.

--- a/releases/v0.21.0.md
+++ b/releases/v0.21.0.md
@@ -11,7 +11,7 @@ This release patches [GHSA-84rc-2q4r-45pc](https://github.com/confidential-conta
 
 Trustee and guest components use Rust v1.90.0.
 
-Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs) for more information.
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
 
 ## Deprecation Notices
 * The CAA docker provider has been deprecated since 0.20 and is planned to be removed in 0.22.


### PR DESCRIPTION
Ignore asciinema.org and docs.redhat.com in lychee checks, as they are valid but fail automated checking (timeouts and bot-blocking 403s). Also add trailing slashes to confidentialcontainers.org/docs links in release notes to avoid a redirect.