### PR TITLE
release: update release notes for v0.22.0

### DIFF
--- a/releases/v0.22.0.md
+++ b/releases/v0.22.0.md
@@ -1,0 +1,105 @@
+# Release Notes for v0.22.0
+
+Release Date: July 28th, 2026
+
+This release is based on [4.0.0](https://github.com/kata-containers/kata-containers/releases/tag/4.0.0) of Kata Containers.
+This Kata release adopts the Rust shim as the default for many runtime classes.
+Confidential Containers still uses the Go shim for now, but will transition in the future.
+
+This release uses v0.21.0 of Trustee and guest components.
+Trustee and the guest components use KBS protocol v0.4.0.
+
+Trustee and guest components use Rust v1.90.0.
+
+Please see the [quickstart guide](https://confidentialcontainers.org/docs/getting-started/) or [project documentation](https://confidentialcontainers.org/docs/) for more information.
+
+## Breaking Changes
+
+* Trustee has a new admin authentication framework. Now the KBS client is invoked
+with an admin token rather than an admin private key.
+
+## Deprecation Notices
+* The CAA docker provider was removed.
+* The Fedora-based mkosi-built CAA podvm image has been removed.
+* The packer-built CAA podvm image has been removed.
+* The CAA csi-wrapper component was removed.
+* In-toto reference value extractor removed from RVPS
+* The warning about simple tokens being deprecated has been removed. Simple token support was dropped in v0.16.0.
+
+## What's New
+
+* Trustee Helm Chart introduced
+* Improvements to Intel verifier (support for offline/air-gapped verification collateral, dropped the dependency to QCNL lib)
+* Improvements to Hygon DCU verifier (supports multiple devices)
+* Improvements to s390x verifier (use SHA-512 for report data)
+* Redis/Valkey storage backend added to Trustee.
+* Improved support for TLS configuration in Trustee
+* Added AWS Secrets Manager resource backend to Trustee
+* Added gRPC Health service endpoints for RVPS and AS and `/healthz` API for KBS
+* Attestation tokens now have an issuer claim
+* Attestation Service exposes token signing keys via well-known JWKS endpoint.
+* Added Trustee CI dashboard
+* Support plugins via the resource URI 
+* Improve image unpacking in image-rs
+* Allow runtime data to be set as base64 when using ASR
+* Added interface to ASR to get additional (device) evidence from workload 
+
+## Hardware Support
+
+Attestation is supported and tested on three platforms: Intel TDX, AMD SEV-SNP, and IBM SEL.
+Not all features have been tested on every platform, but those based on attestation
+are expected to work on the platforms above.
+
+Make sure your host platform is compatible with the hypervisor and guest kernel
+provisioned by CoCo.
+
+This release has been tested on the following stacks:
+
+### AMD SEV-SNP
+
+* Processor: AMD EPYC 7713
+* Kernel: 6.16.0
+* OS: Ubuntu 24.04 LTS
+* k8s: v1.34.2 (Kubeadm)
+* Kustomize: v5.7.1
+* Containerd: v1.7.29
+
+### Intel TDX
+
+* Kernel: 6.17.0-14-generic
+* OS: Ubuntu 24.04.4 LTS
+* k8s: v1.36.2 (Kubeadm)
+* Kustomize: v5.7.1
+
+### IBM Secure Execution for Linux (SEL)
+
+* Hardware: IBM z17 LPAR
+* Kernel: 6.8.0-136-generic
+* OS: Ubuntu 24.04.2 LTS
+* k8s: v1.36.2 (Kubeadm)
+* Kustomize: v5.8.1
+
+### NVIDIA
+
+There are two NVIDIA runners.
+
+* Hardware: AMD EPYC 9274F and NVIDIA Corporation GH100
+* Kernel: 7.0.0-15-generic
+* OS: Ubuntu 26.04
+* k8s: v1.34.1
+* Kustomize: v5.7.1
+* Containerd: v2.3.0
+
+## Limitations
+
+The following are limitations and known issues with this release.
+
+* Credentials for authenticated registries are exposed to the host.
+* LUKS-based secure storage provides integrity protection, but not replay protection.
+* Not all features are tested on all platforms.
+* Guest pull with nydus snapshotter sometimes fails.
+* Guest pull may have negative performance implications.
+* `crio` support is still evolving.
+* Containerd versions older than v2.3.x may have issues with guest pull.
+* SELinux is not supported on the host and must be set to permissive if in use.
+* A secure Kata agent policy must be used to protect the guest, but this may not support some Kubernetes commands, such as exec.


### PR DESCRIPTION
Another great release.

Need updates about the deprecations in CAA and the CI runners.