### PR TITLE
policy: add an AI policy

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,93 @@
+# Confidential Containers AI Development Policy
+
+Confidential Containers welcomes high quality contributions from any source,
+created using any tools.
+
+That said, this project's greatest assets are the humans that work on it
+and the community we all create together.
+
+This document delineates policies and best practices for taking advantage of AI tools
+while maintaining a strong community.
+
+AI capabilities are changing rapidly. This document is based on the current landscape only
+and should evolve as needed.
+
+## Policies
+
+These policies are mandatory
+
+### You are solely responsible for content submitted under your name
+
+No matter how it is created, any content submitted on your behalf (including by agents)
+is your responsibility.
+You should understand the entirety of your submissions and the discussion around your work.
+When you sign-off on a commit, you personally vouch for its quality.
+
+### Be mindful of maintainers' time
+
+In Confidential Containers, high quality human review is standard.
+AI tools may be used to assist with code review, but maintainers should only merge code that they
+are personally confident in.
+To do so, maintainers need to understand both the changes and the existing code. This takes time.
+Across the entire submission flow, try to simplify the review process for maintainers.
+Following from the previous policy, do not submit code for review if you have not reviewed it yourself.
+More specific suggestions are given below.
+This mindset is crucial given recent increases in submissions.
+
+### Identify when AI is used
+
+Identify AI usage in your commit messages.
+For example, `Assisted-by: Cursor` or `Co-authored-by: Cursor <cursoragent@cursor.com>`
+
+For now, the community does not require any particular format.
+
+
+## Best Practices
+
+These are suggestions for how to contribute.
+
+### Don't use AI for prose
+
+A good way to practice and demonstrate thoughtfulness about your work
+is to write commit messages and PR summaries yourself.
+
+There are exceptions if you are not comfortable writing in English,
+but don't worry about having perfect grammar or style.
+Hearing contributor's unique voices bolsters the community.
+More importantly, these fields help maintainers understand your work.
+Providing concise and thoughtful prose saves time for everyone.
+
+Furthermore, avoid submitting issues that are generated entirely by AI
+or responding to issues with AI comments.
+Most contributors have access to AI tools that they can use themselves.
+Issues are a place for elevated, community discussion.
+
+Long blocks of AI-generated prose are unlikely to be prioritized by maintainers.
+Taking a little extra time to write high quality text will usually help your
+work be reviewed and merged faster.
+
+CVEs are a particularly significant form of issue.
+AI can be great at discovering vulnerabilities, but study the trust model
+and the implications yourself and submit your own concise description.
+
+### Lean towards brevity in your submissions
+
+Generally speaking, try to make your submissions concise.
+It is easier than ever to add more code to a project, but every line we add
+needs to be maintained.
+Make sure everything you submit is necessary and is implemented as simply as it can be.
+
+If you're not sure, create an issue before writing any code.
+ 
+### Provide your own value on top of the tools
+
+Your PRs should be more than a pipe between GitHub and an AI agent.
+The community benefits from your perspective and experience.
+Iterate on your work before submitting it and consider feedback carefully.
+Do not feed reviewer comments directly back into an agent.
+
+### Express yourself and connect with others
+
+Don't underestimate how important you are to this community.
+Join the community on slack and come to meetings (timezone and language permitting).
+Add a personal touch to your GitHub profile and have some fun.


### PR DESCRIPTION
Following from discussions in the community meeting, let's add an official AI policy.

Things are moving pretty fast. We may update this before long, but this seems like a reasonable starting point.

This was already discussed in https://github.com/confidential-containers/.github/pull/26 but turns out the PR should really be to this repo.